### PR TITLE
Add error handling to API calls

### DIFF
--- a/src/outleap/api_wrappers.py
+++ b/src/outleap/api_wrappers.py
@@ -37,8 +37,8 @@ async def _data_unwrapper(data_fut: Awaitable[Dict], inner_elem: str) -> Any:
     # but that means that we have to return a `Coroutine` that will pull the value out of the dict
     # rather than directly returning the `Future`.
     response = await data_fut
-    if 'error' in response and response['error']:
-        raise LEAPAPIError(response['error'], response)
+    if err_msg := response.get('error'):
+        raise LEAPAPIError(err_msg, response)
     return response[inner_elem]
 
 

--- a/src/outleap/api_wrappers.py
+++ b/src/outleap/api_wrappers.py
@@ -24,6 +24,7 @@ class LEAPAPIWrapper(abc.ABC):
 
 class LEAPAPIError(Exception):
     """Error reported from API."""
+
     response_data: Dict
 
     def __init__(self, error_message: str, response_data: Dict):
@@ -37,7 +38,7 @@ async def _data_unwrapper(data_fut: Awaitable[Dict], inner_elem: str) -> Any:
     # but that means that we have to return a `Coroutine` that will pull the value out of the dict
     # rather than directly returning the `Future`.
     response = await data_fut
-    if err_msg := response.get('error'):
+    if err_msg := response.get("error"):
         raise LEAPAPIError(err_msg, response)
     return response[inner_elem]
 

--- a/src/outleap/api_wrappers.py
+++ b/src/outleap/api_wrappers.py
@@ -38,7 +38,7 @@ async def _data_unwrapper(data_fut: Awaitable[Dict], inner_elem: str) -> Any:
     # but that means that we have to return a `Coroutine` that will pull the value out of the dict
     # rather than directly returning the `Future`.
     response = await data_fut
-    if 'error' in response:
+    if 'error' in response and response['error']:
         raise APIError(response)
     return response[inner_elem]
 

--- a/src/outleap/api_wrappers.py
+++ b/src/outleap/api_wrappers.py
@@ -22,13 +22,13 @@ class LEAPAPIWrapper(abc.ABC):
         assert self._pump_name
 
 
-class APIError(Exception):
+class LEAPAPIError(Exception):
     """Error reported from API."""
     response_data: Dict
 
-    def __init__(self, response_data):
+    def __init__(self, error_message: str, response_data: Dict):
+        super().__init__(error_message)
         self.response_data = response_data
-        super().__init__(self.response_data['error'])
 
 
 async def _data_unwrapper(data_fut: Awaitable[Dict], inner_elem: str) -> Any:
@@ -38,7 +38,7 @@ async def _data_unwrapper(data_fut: Awaitable[Dict], inner_elem: str) -> Any:
     # rather than directly returning the `Future`.
     response = await data_fut
     if 'error' in response and response['error']:
-        raise APIError(response)
+        raise LEAPAPIError(response['error'], response)
     return response[inner_elem]
 
 

--- a/src/outleap/api_wrappers.py
+++ b/src/outleap/api_wrappers.py
@@ -22,12 +22,25 @@ class LEAPAPIWrapper(abc.ABC):
         assert self._pump_name
 
 
+class APIError(Exception):
+    """Error reported from API."""
+    response_data: Dict
+
+    def __init__(self, response_data):
+        self.response_data = response_data
+        super().__init__(self.response_data['error'])
+
+
+
 async def _data_unwrapper(data_fut: Awaitable[Dict], inner_elem: str) -> Any:
     """Unwraps part of the data future while allowing the request itself to remain synchronous"""
     # We want the request to be sent immediately, without requiring the request to be `await`ed first,
     # but that means that we have to return a `Coroutine` that will pull the value out of the dict
     # rather than directly returning the `Future`.
-    return (await data_fut)[inner_elem]
+    response = await data_fut
+    if 'error' in response:
+        raise APIError(response)
+    return response[inner_elem]
 
 
 class CommandAPI(LEAPAPIWrapper):

--- a/src/outleap/api_wrappers.py
+++ b/src/outleap/api_wrappers.py
@@ -31,7 +31,6 @@ class APIError(Exception):
         super().__init__(self.response_data['error'])
 
 
-
 async def _data_unwrapper(data_fut: Awaitable[Dict], inner_elem: str) -> Any:
     """Unwraps part of the data future while allowing the request itself to remain synchronous"""
     # We want the request to be sent immediately, without requiring the request to be `await`ed first,


### PR DESCRIPTION
Add small fix for error handling when the LEAP API returns an error response to make things easier to debug. I also kept the `response_data` in case there's extra data outside the error key.